### PR TITLE
Removed dead Lief link from requirements.txt, replace with working link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ h5py==2.7.0
 ipython==6.1.0
 keras==2.0.5
 keras-rl==0.3.0
-https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip
+https://github.com/lief-project/LIEF/releases/download/0.7.0/linux_lief-0.7.0_py3.6.tar.gz
 numpy==1.13.1
 requests==2.18.1
 scikit-learn==0.18.2


### PR DESCRIPTION
Old Link was throwing a 404 and causing errors when trying to install the requirements.

  HTTP error 404 while getting https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip
  Could not install requirement https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip (from -r requirements.txt (line 6)) because of error 404 Client Error: Not Found for url: https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip
Could not install requirement https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip (from -r requirements.txt (line 6)) because of HTTP error 404 Client Error: Not Found for url: https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip for URL https://github.com/lief-project/packages/raw/lief-master-latest/pylief-0.7.0.dev.zip